### PR TITLE
Update view3d_point_cloud_visualizer.py

### DIFF
--- a/view3d_point_cloud_visualizer.py
+++ b/view3d_point_cloud_visualizer.py
@@ -1410,7 +1410,8 @@ class PCV_OT_render(Operator):
             shader.bind()
             
             view_matrix = cam.matrix_world.inverted()
-            camera_matrix = cam.calc_matrix_camera(bpy.context.depsgraph, x=render.resolution_x, y=render.resolution_y, scale_x=render.pixel_aspect_x, scale_y=render.pixel_aspect_y, )
+            depsgraph = bpy.context.evaluated_depsgraph_get()
+            camera_matrix = cam.calc_matrix_camera(depsgraph, x=render.resolution_x, y=render.resolution_y, scale_x=render.pixel_aspect_x, scale_y=render.pixel_aspect_y, )
             perspective_matrix = camera_matrix @ view_matrix
             
             shader.uniform_float("perspective_matrix", perspective_matrix)
@@ -1498,7 +1499,7 @@ class PCV_OT_render(Operator):
             vs = scene.view_settings
             vsvt = vs.view_transform
             vsl = vs.look
-            vs.view_transform = 'Default'
+            vs.view_transform = 'Standard'
             vs.look = 'None'
             
             s.file_format = 'PNG'


### PR DESCRIPTION
I made this change because I was unable to render the pointcloud.

1) It seemed like depsgraph was not defined
2) the vs.view_transform mode needed changing to 'Standard'

Fixed to work with latest blender 2.8:
**Blender Version**
Broken: version: 2.80 (sub 74), branch: blender2.7, commit date: 2019-06-14 00:12, hash: `rB8ac0fef4dfd1`
Worked: (optional)